### PR TITLE
DOC: Increase introduction notebook consistency

### DIFF
--- a/notebooks/intro_to_datalad.ipynb
+++ b/notebooks/intro_to_datalad.ipynb
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To use its python interface, you can import the `datalad.api as dl`.\n",
+    "To use its Python interface, you can import the `datalad.api as dl`.\n",
     "\n",
     "To get more information about the `datalad` command, I can type `datalad --help`:"
    ]
@@ -116,7 +116,7 @@
     "You can find more details about how to install DataLad and its dependencies on\n",
     "all operating systems in the DataLad handbook, in the section install.\n",
     "It also details how to install DataLad on shared machines that\n",
-    "you don’t have administrative privileges (sudo rights) on, such as high\n",
+    "you don't have administrative privileges (sudo rights) on, such as high\n",
     "performance compute clusters.\n",
     "If you already have datalad installed,\n",
     "**make sure that it is a recent version, at least 0.15 or higher**:"
@@ -137,12 +137,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The very first thing to do if you haven’t done so yet is to configure your Git\n",
-    "identity. Don’t worry if you have never used Git. The identity you are\n",
+    "The very first thing to do if you haven't done so yet is to configure your Git\n",
+    "identity. Don't worry if you have never used Git. The identity you are\n",
     "configuring consists of your name and email-adress so that the changes that you\n",
     "do to a project can be associated with you as an author of the changes.\n",
     "\n",
-    "Below, we demonstrate how this can be done. However, a central git configuration has already been completed for you in this notebook, so you don't have to do this explicitly. That is why the code below is commented out."
+    "Below, we demonstrate how this can be done. However, a central Git configuration has already been completed for you in this notebook, so you don't have to do this explicitly. That is why the code below is commented out."
    ]
   },
   {
@@ -214,13 +214,13 @@
    "source": [
     "Datasets have the exciting features that they can record\n",
     "everything that is done inside of them, version control all content given to\n",
-    "Datalad, regardless of the size this content, and have a complete history that\n",
+    "DataLad, regardless of the size this content, and have a complete history that\n",
     "you can interact with. This history is already present, although it is very\n",
-    "short at this point in time. Let’s check it out nevertheless.\n",
+    "short at this point in time. Let's check it out nevertheless.\n",
     "\n",
     "This history exists thanks to Git. Therefore, you can access the history of a\n",
-    "dataset with any tool that shows you git\n",
-    "history. We’ll stay basic and just use gits build-in `git log` command, but you\n",
+    "dataset with any tool that shows you Git\n",
+    "history. We'll stay basic and just use Git's built-in `git log` command, but you\n",
     "could also use tools with graphical user interfaces if you want to, for example\n",
     "tig:"
    ]
@@ -244,10 +244,10 @@
     "\n",
     "## 2. Version control workflows\n",
     "\n",
-    "I’ll start by creating a books directory with the `mkdir` command, and then I will download two books\n",
-    "from the internet. Here, I’m using the command line tool `wget` to do this in\n",
-    "order to do everything from the commandline. But you can also just download the\n",
-    "book manually and save it into the dataset with a file manager if you are more\n",
+    "I'll start by creating a `books` directory with the `mkdir` command, and then I will download two books\n",
+    "from the internet. Here, I'm using the command line tool `wget` to do this in\n",
+    "order to do everything from the command line. But you can also just download the\n",
+    "books manually and save them into the dataset with a file manager if you are more\n",
     "comfortable doing it this way. Remember, a dataset is just a directory on your\n",
     "computer:"
    ]
@@ -315,8 +315,8 @@
     "Use the `datalad status` command to find out what happened in the dataset. This\n",
     "command is very helpful and reports on the current state of your dataset. Any\n",
     "content that is new or changed will be highlighted. If nothing has changed, a\n",
-    "datalad status will report what is called a clean dataset state. And in general\n",
-    "it is very useful to always have a clean dataset state:"
+    "`datalad status` will report what is called a **clean dataset state**. And in\n",
+    "general it is very useful to always have a clean dataset state:"
    ]
   },
   {
@@ -337,7 +337,7 @@
     "Any content that\n",
     "we want DataLad to manage needs to be explicitly given to DataLad, it is not\n",
     "enough to simply put it inside of the dataset. To give new or changed content to\n",
-    "DataLad, we need to save it using datalad save. This is the first time that we\n",
+    "DataLad, we need to save it using `datalad save`. This is the first time that we\n",
     "need to specify a commit message, and this is done with the `-m` option of the\n",
     "command:"
    ]
@@ -357,7 +357,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With `git log -n 1` you can take a look at the most recent commit in the history:"
+    "With `git log -p -n 1` you can take a look at the most recent commit in the history,\n",
+    "as well as the changes that were saved in that commit:"
    ]
   },
   {
@@ -375,11 +376,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`datalad save` saved all untracked contents to the dataset. Sometimes this is inconvinient. One great advantage of a datasets\n",
+    "`datalad save` saved all untracked contents to the dataset. Sometimes this is inconvenient. One great advantage of a datasets\n",
     "history is that it allows you to revert changes you are not happy with, but this\n",
-    "is only easily possible in the units of single commits. So if one save commits\n",
-    "several unrelated files or changes, they are hard to disentangle if you ever\n",
-    "want to revert some of those changes. But if you for example provide a path to\n",
+    "is only easily possible in the units of single commits. So if one saves commits\n",
+    "to several unrelated files or changes, they are hard to disentangle if you ever\n",
+    "want to revert some of those changes. But if you, for example, provide a path to\n",
     "the file you want to save you can specify more precisiley what will be saved\n",
     "together:"
    ]
@@ -472,7 +473,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Datalad status will, as expected, say that there is a new untracked file in the\n",
+    "`datalad status` will, as expected, say that there is a new untracked file in the\n",
     "dataset:"
    ]
   },
@@ -491,8 +492,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can save it with datalad save command and a helpful commit message. As\n",
-    "its the only change in the dataset, there is no need to provide a path:"
+    "We can save it with the `datalad save` command and a helpful commit message. As\n",
+    "it is the only change in the dataset, there is no need to provide a path:"
    ]
   },
   {
@@ -510,7 +511,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let’s now add another note to modifiy this file:"
+    "Let's now add another note to modifiy this file:"
    ]
   },
   {
@@ -533,8 +534,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A datalad status reports the file not to be untracked, but because it\n",
-    "differs now from the state it was saved under it is reported to be modified:"
+    "A `datalad status` reports the file not to be untracked, but because it\n",
+    "differs now from the state it was saved under, it is reported to have been\n",
+    "modified:"
    ]
   },
   {
@@ -552,7 +554,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let’s save this:"
+    "Let's save this:"
    ]
   },
   {
@@ -611,12 +613,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Afterwards, I’ll install the dataset I am interested in, either from a path or\n",
+    "Afterwards, I'll install the dataset I am interested in, either from a path or\n",
     "a URL. The dataset I want to install lives on GitHub, so in order to get it, I\n",
-    "will privide its URL to the datalad clone command. I’m also attaching a path to\n",
-    "where I want to have it installed to this call. Importantly I am installing this\n",
-    "dataset as a subdataset of `DataLad-101`, in other words I will nest the two\n",
-    "datasets inside of each other. This is done with the `--dataset` flag:"
+    "will provide its URL to the `datalad clone` command. I'm also attaching to this\n",
+    "call a path to where I want to have it installed. Importantly, I am installing\n",
+    "this dataset as a subdataset of `DataLad-101`; in other words, I will nest the\n",
+    "two datasets. This is done with the `--dataset` flag:"
    ]
   },
   {
@@ -634,7 +636,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are new directories in my DataLad/101 dataset, and in these new directories, there are\n",
+    "There are new directories in my `DataLad/101 dataset`, and in these new directories, there are\n",
     "hundreds of mp3 files:"
    ]
   },
@@ -672,11 +674,11 @@
    "metadata": {},
    "source": [
     "here is the crucial and incredibly\n",
-    "handy feature of DataLad datasets: At this point, after cloning, the dataset\n",
-    "has small files, for example the README, but larger files in it don’t have any\n",
-    "file content yet. It only retrieved what we in a simplified way call file\n",
-    "availability metadata and shows that as the file hierarchy in the dataset. So\n",
-    "while I can read the file names and find out what the dataset contains, I don’t\n",
+    "handy feature of DataLad datasets: at this point, after cloning, the dataset\n",
+    "has small files, for example the `README`, but larger files in it don't have any\n",
+    "file content yet. It only retrieved what we, in a simplified way, call **file\n",
+    "availability metadata**, and shows that as the file hierarchy in the dataset. So\n",
+    "while I can read the file names and find out what the dataset contains, I don't\n",
     "have the file contents yet. If I would try to play one of the recordings with the VLC player, this would fail:"
    ]
   },
@@ -724,7 +726,7 @@
    "metadata": {},
    "source": [
     "It is tiny! But we can also find out how large the dataset would be if we had all\n",
-    "of its contents with datalad status and the `--annex` flag. In total, there are\n",
+    "of its contents with `datalad status` and the `--annex` flag. In total, there are\n",
     "more than 15GB of podcasts you have now access to:"
    ]
   },
@@ -781,7 +783,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you don’t need the data locally anymore you can\n",
+    "If you don't need the data locally anymore, you can\n",
     "drop the content from your dataset to save diskspace:"
    ]
   },
@@ -823,8 +825,8 @@
     "\n",
     "## 4. Dataset nesting\n",
     "\n",
-    "Let’s take a look into the history of the longnow subdataset:\n",
-    "We can see that it has preserved its history completely. This means that the data we\n",
+    "Let's take a look into the history of the `longnow` subdataset:\n",
+    "we can see that it has preserved its history completely. This means that the data we\n",
     "retrieved preserved all of its provenance:"
    ]
   },
@@ -843,10 +845,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "How does this look in the top-level dataset? If we query DataLad-101s history,\n",
+    "How does this look in the top-level dataset? If we query `DataLad-101`'s history,\n",
     "there will be no commit about mp3 files or any of the commits we have seen in\n",
     "the subdataset. Instead, we can see that the superdataset recorded\n",
-    "the `recordings/longnow` dataset as a subdataset. This means, that it recorded where this dataset\n",
+    "the `recordings/longnow` dataset as a subdataset. This means that it recorded where this dataset\n",
     "came from and what version it is in:"
    ]
   },
@@ -915,7 +917,7 @@
     "\n",
     "## 5. More on data versioning, nesting, and a glimpse into reproducible paper\n",
     "\n",
-    "We’ll clone a repository for a paper that shares manuscript, code, and data:"
+    "We'll clone a repository for a paper that shares the manuscript, the code, and the data:"
    ]
   },
   {
@@ -942,8 +944,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The top-level dataset has many subdatasets. One of it, remodnav, is a dataset that contains the sourcecode for a Python\n",
-    "package called remodnav used in eyetracking analyses:"
+    "The top-level dataset has many subdatasets. One of it, `remodnav`, is a dataset that contains the source code for a Python\n",
+    "package called `remodnav` used in eyetracking analyses:"
    ]
   },
   {
@@ -1028,16 +1030,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This command doesn’t only retrieve file contents, but it also installs\n",
+    "This command doesn't only retrieve file contents, but it also installs\n",
     "subdatasets. So if you want to be really lazy, just run datalad get `--recursive -n` in the root of a dataset to install all subdatasets that are available.\n",
-    "The `-n` option prevents get from downloading any data, so that only subdataset\n",
+    "The `-n` option prevents `get` from downloading any data, so that only subdatasets\n",
     "are installed, but no data is downloaded. Here, the depth of recursion is limited.\n",
     "For one, it would take a while to install all subdatasets, but the very raw eye tracking\n",
     "dataset contains subject IDs that should not be shared, and therefore, this subdataset\n",
     "is not accessible - if you try to install all subdatasets, the source eyetracking\n",
     "data will throw an error, because it is not made publicly available.\n",
     "\n",
-    "Afterwards, you can see that the remodnav subdataset also contains further\n",
+    "Afterwards, you can see that the `remodnav` subdataset also contains further\n",
     "subdatasets. In this case, these subdatasets contain data that is used for\n",
     "testing and validating software performance:"
    ]
@@ -1089,7 +1091,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But because I can link subdatasets in precise version I can\n",
+    "But because I can link subdatasets in precise version, I can\n",
     "consciously decide and openly record which version of the data I am using or\n",
     "even test how much my results change by resetting the subdataset to an ealier\n",
     "state or updating the dataset to a more recent version."
@@ -1123,7 +1125,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, create a new dataset, in this case with the yoda configuration:"
+    "First, create a new dataset, in this case with the `yoda` configuration:"
    ]
   },
   {
@@ -1141,7 +1143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This sets up a helpful structure for my dataset with a code directory and some README files,\n",
+    "This sets up a helpful structure for my dataset with a code directory and some `README` files,\n",
     "and applies helpful configurations:"
    ]
   },
@@ -1169,12 +1171,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Read up more about the YODA principles and the yoda configuration in the section\n",
-    "yoda.\n",
+    "Read up more about the YODA principles and the `yoda` configuration in the `yoda`\n",
+    "section.\n",
     "\n",
     "Next, install input data as a subdataset. For this, I created a\n",
-    "dataset with the Iris data and published it on Github. Here, we’re installing it\n",
-    "into a directory `input`:"
+    "dataset with the `Iris` data and published it on GitHub. Here, we're installing\n",
+    "it into a directory `input`:"
    ]
   },
   {
@@ -1192,9 +1194,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The last thing is code to run on the data and produce results. For this, here is a\n",
+    "The last piece is the code to run on the data and produce results. For this, here is a\n",
     "k-means classification analysis script written in Python. You can find this analysis\n",
-    "in more detail in the section yoda_project:"
+    "in more detail in the `yoda_project` section:"
    ]
   },
   {
@@ -1272,8 +1274,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let’s save it with a datalad save command and also attach an identifier with the\n",
-    "`--version-tag` flag:"
+    "Let's save it with a `datalad save` command and also attach an identifier with\n",
+    "the `--version-tag` flag:"
    ]
   },
   {
@@ -1293,7 +1295,7 @@
    "source": [
     "The challenge DataLad helps me to accomplish is running this script in a way\n",
     "that links the script to the results it produces and the data it was computed\n",
-    "from. I can do this with the datalad run command. In principle, it is simple.\n",
+    "from. I can do this with the `datalad run` command. In principle, it is simple.\n",
     "You start with a clean dataset:"
    ]
   },
@@ -1312,14 +1314,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then, give the command you would execute to datalad run, in this case `python code/script.py`.\n",
-    "Datalad will take the command, run it, and save all of the changes in the\n",
-    "dataset that this leads this to under the commit message specified with\n",
+    "Then, give the command you would execute to `datalad run`, in this case `python code/script.py`.\n",
+    "DataLad will take the command, run it, and save all of the changes in the\n",
+    "dataset that this leads to under the commit message specified with\n",
     "the `-m` option. Thus, it associates the script with the results.\n",
     "But it can be even more helpful. Here, we also specify the input data the command\n",
-    "needs and datalad will get the data beforehand. And we also specify the output\n",
+    "needs and DataLad will get the data beforehand. And we also specify the output\n",
     "of the command. To understand fully what this does, please read chapters\n",
-    "chapter_run and chapter_gitannex, but specifying the outputs will allow me later to rerun\n",
+    "`chapter_run` and `chapter_gitannex`, but specifying the outputs will allow me later to rerun\n",
     "the command and let me update outdated results:"
    ]
   },
@@ -1342,7 +1344,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Datalad creates a commit in my history. This commit has my commit\n",
+    "DataLad creates a commit in my history. This commit has my commit\n",
     "message as a human readable summary of what was done, it contains the produced\n",
     "output, and it has a machine readable record that contains information on the\n",
     "input data, the results, and the command that was run to create this result:"
@@ -1364,9 +1366,9 @@
    "metadata": {},
    "source": [
     "This machine readable record is particularly helpful, because I can now instruct\n",
-    "datalad to rerun this command so that I don’t have to memorize what I had done\n",
-    "and people I share my dataset with don’t need to ask me how this result was\n",
-    "produced, by can simply let DataLad tell them.\n",
+    "DataLad to rerun this command so that I don't have to memorize what I had done\n",
+    "and people I share my dataset with don't need to ask me how this result was\n",
+    "produced, but can simply let DataLad tell them.\n",
     "\n",
     "This is done with the `datalad rerun` command. For this demonstration, I have\n",
     "prepared this analysis dataset and published it to GitHub at\n",
@@ -1406,9 +1408,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "I can clone this repository and give for example the checksum of the run command\n",
-    "to the `datalad rerun` command. DataLad will read the machine readable record of\n",
-    "what was done and recompute the exact same thing:"
+    "I can clone this repository and give, for example, the checksum of the\n",
+    "`datalad run` command to the `datalad rerun` command. DataLad will read the\n",
+    "machine readable record of what was done and recompute the exact same thing:"
    ]
   },
   {
@@ -1450,8 +1452,8 @@
     "\n",
     "## 7. Computational reproducibility\n",
     "\n",
-    "If you don’t have the required python packages available, running the script and\n",
-    "computing the results will fail. In order to be computationally reproducible\n",
+    "If you don't have the required Python packages available, running the script and\n",
+    "computing the results will fail. In order to be computationally reproducible,\n",
     "I need to attach the software that is necessary for a computation to this\n",
     "execution record:"
    ]
@@ -1471,16 +1473,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the way I can do this is with a datalad extension called datalad containers.\n",
+    "And the way I can do this is with a DataLad extension called `datalad containers`.\n",
     "You can install this extension with pip by running\n",
     "`pip install datalad-containers`.\n",
-    "This extension allow to attach software containers such as singularity\n",
+    "This extension allows to attach software containers such as Singularity\n",
     "images to my dataset and execute my commands inside of these containers. Thus, I\n",
     "can share share data, code, code execution, and software.\n",
     "\n",
-    "Here is how this works: First, I attach a software container to my dataset using\n",
+    "Here is how this works: first, I attach a software container to my dataset using\n",
     "`datalad containers-add` with a name of the container (here I call it `software`)\n",
-    "and a url or path where to find this container, here it is singularity hub. This\n",
+    "and a URL or path where to find this container; here, at Singularity Hub. This\n",
     "records the software in the dataset:"
    ]
   },
@@ -1499,13 +1501,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: You need to have [singularity](https://sylabs.io/guides/3.5/user-guide/)\n",
+    "Note: You need to have [Singularity](https://sylabs.io/guides/3.5/user-guide/)\n",
     "installed to run this!\n",
     "\n",
     "Afterwards, rerun the analysis in the software container with the\n",
-    "`datalad containers-run` command. This container works just as the run command before, I\n",
+    "`datalad containers-run` command. This container works just as the `datalad run` command before, I\n",
     "only need to specify the container name. If you were to rerun such an analysis,\n",
-    "datalad would not only retrieve the input data but also the software container:"
+    "DataLad would not only retrieve the input data but also the software container:"
    ]
   },
   {
@@ -1528,7 +1530,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Read more about this in the section containersrun.\n",
+    "Read more about this in the section `containersrun`.\n",
     "\n",
     "**Done! Thanks for coding along!**"
    ]


### PR DESCRIPTION
Increase the introduction notebook consistency:
- Fix misspellings and grammar errors.
- Consistently use the straight tick to mark contractions.
- Highlight the syntax for DataLad commands, and the other special names, such as the folders used to illustrate the cases.
- Use consistently the same case to name `DataLad`.
- Capitalize letters consistently (e.g. `Git`, `GitHub`, etc.) where appropriate.