### PR TITLE
ENH: add bash kernel notebook for using with jupyter-params

### DIFF
--- a/notebooks/binder/download_data_with_datalad.ipynb
+++ b/notebooks/binder/download_data_with_datalad.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Required parameters (DO NOT EDIT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clone DataLad Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datalad clone $repourl"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Bash",
+   "language": "bash",
+   "name": "bash"
+  },
+  "language_info": {
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "bash"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This serves as a new version for what currently exists at https://github.com/jsheunis/datalad-notebooks/blob/main/download_data_with_datalad_bash.ipynb. To be used by `datalad-catalog` with the `datalad-binder` repo to allow users to explore datalad datasets.